### PR TITLE
Add digimon exclusion filter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { ThemeToggle } from "./components/theme-toggle";
 import { Button } from "./components/ui/button";
 import { Digimon } from "./types";
 import SkillsSelector from "./components/skills-selector";
+import ExcludedDigimonSelector from "./components/excluded-digimon-selector";
 import { PathStep } from "./lib/path-finder";
 import { DigimonSelector } from "./components/digimon-selector";
 import EvolutionPath from "./components/evolution-path";
@@ -17,6 +18,7 @@ function App() {
   const [targetDigimon, setTargetDigimon] = useState<Digimon | null>(null);
   const [targetSearchValue, setTargetSearchValue] = useState("");
   const [skills, setSkills] = useState<string[]>([]);
+  const [excludedDigimonIds, setExcludedDigimonIds] = useState<string[]>([]);
 
   const [path, setPath] = useState<PathStep[] | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -35,6 +37,7 @@ function App() {
       originDigimon,
       targetDigimon,
       skills,
+      excludedDigimonIds,
     });
     worker.onmessage = (e: MessageEvent<PathStep[]>) => {
       const newPath = e.data;
@@ -90,6 +93,10 @@ function App() {
             <SkillsSelector
               selectedSkills={skills}
               onSelectedSkillsChange={setSkills}
+            />
+            <ExcludedDigimonSelector
+              excludedDigimonIds={excludedDigimonIds}
+              onExcludedDigimonIdsChange={setExcludedDigimonIds}
             />
             <div className="w-full flex justify-center">
               <Button

--- a/src/components/excluded-digimon-selector.tsx
+++ b/src/components/excluded-digimon-selector.tsx
@@ -1,0 +1,92 @@
+import { useMemo, useState } from "react";
+import { X } from "lucide-react";
+import { AutoComplete } from "./ui/autocomplete";
+import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
+import digimonDb from "@/db/db.json";
+import { Digimon } from "@/types";
+
+const digimons = digimonDb as Record<string, Digimon>;
+
+interface Props {
+  excludedDigimonIds: string[];
+  onExcludedDigimonIdsChange: (ids: string[]) => void;
+}
+
+const ExcludedDigimonSelector = ({ excludedDigimonIds, onExcludedDigimonIdsChange }: Props) => {
+  const [searchValue, setSearchValue] = useState("");
+  const [selectedValue, setSelectedValue] = useState("");
+
+  const digimonOptions = useMemo(() => {
+    return Object.values(digimons).map((d) => ({ value: d.id.toString(), label: d.name }));
+  }, []);
+
+  const handleSelect = (value: string) => {
+    if (!excludedDigimonIds.includes(value)) {
+      onExcludedDigimonIdsChange([...excludedDigimonIds, value]);
+    }
+    setSelectedValue("");
+    setSearchValue("");
+  };
+
+  const handleRemove = (id: string) => {
+    onExcludedDigimonIdsChange(excludedDigimonIds.filter((d) => d !== id));
+  };
+
+  return (
+    <div>
+      <label
+        className="block mb-2 text-sm font-medium text-accent-foreground"
+        htmlFor="excludedDigimon"
+      >
+        Exclude Digimon
+      </label>
+      <div className="space-y-2">
+        <AutoComplete
+          selectedValue={selectedValue}
+          onSelectedValueChange={(value) => {
+            setSelectedValue(value);
+            if (value) {
+              handleSelect(value);
+            }
+          }}
+          searchValue={searchValue}
+          onSearchValueChange={setSearchValue}
+          items={digimonOptions
+            .filter((d) => d.label.toLowerCase().includes(searchValue.toLowerCase()))
+            .slice(0, 10)}
+          placeholder="Search digimon..."
+          renderLabel={(id) => {
+            const digimon = digimons[id];
+            return (
+              <div className="flex items-center gap-2">
+                <img src={`/icons/${id}.png`} alt={digimon.name} className="w-8 h-8" />
+                {digimon.name}
+              </div>
+            );
+          }}
+        />
+        <div className="flex flex-wrap gap-2">
+          {excludedDigimonIds.map((id) => (
+            <Badge
+              key={id}
+              className="flex items-center gap-1 bg-red-100/80 hover:bg-red-200/80 text-red-900 dark:bg-red-900/20 dark:hover:bg-red-900/30 dark:text-red-200 border-0 px-3 py-1"
+            >
+              {digimons[id].name}
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-4 w-4 hover:bg-transparent cursor-pointer p-0 ml-1"
+                onClick={() => handleRemove(id)}
+              >
+                <X className="h-3 w-3 text-red-900/70 dark:text-red-200/70" />
+              </Button>
+            </Badge>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExcludedDigimonSelector;

--- a/src/lib/path-finder/index.ts
+++ b/src/lib/path-finder/index.ts
@@ -37,13 +37,21 @@ const typedLearnersByMoveId = learnersByMoveId as LearnersByMoveId;
 export const findPath = (
   originDigimon: Digimon,
   targetDigimon: Digimon,
-  skills: string[]
+  skills: string[],
+  excludedDigimonIds: string[] = []
 ): PathStep[] | null => {
+  if (
+    excludedDigimonIds.includes(originDigimon.id.toString()) ||
+    excludedDigimonIds.includes(targetDigimon.id.toString())
+  ) {
+    return null;
+  }
   // If no skills required, just find shortest path
   if (skills.length === 0) {
     return findShortestPath(
       originDigimon.id.toString(),
-      targetDigimon.id.toString()
+      targetDigimon.id.toString(),
+      excludedDigimonIds
     );
   }
 
@@ -99,6 +107,7 @@ export const findPath = (
 
     // Explore next digimon in evolution line
     for (const nextId of currentDigimon.neighBours.next) {
+      if (excludedDigimonIds.includes(nextId)) continue;
       queue.push({
         digimonId: nextId,
         learnedMoves: new Set(newLearnedMoves),
@@ -108,6 +117,7 @@ export const findPath = (
 
     // Explore previous digimon in evolution line
     for (const prevId of currentDigimon.neighBours.prev) {
+      if (excludedDigimonIds.includes(prevId)) continue;
       queue.push({
         digimonId: prevId,
         learnedMoves: new Set(newLearnedMoves),
@@ -123,7 +133,8 @@ export const findPath = (
 // Helper function to find shortest path without move requirements
 function findShortestPath(
   originId: string,
-  targetId: string
+  targetId: string,
+  excludedDigimonIds: string[] = []
 ): PathStep[] | null {
   const queue: { digimonId: string; path: PathStep[] }[] = [
     {
@@ -146,6 +157,7 @@ function findShortestPath(
     const currentDigimon = typedDigimonDb[current.digimonId];
 
     for (const nextId of currentDigimon.neighBours.next) {
+      if (excludedDigimonIds.includes(nextId)) continue;
       queue.push({
         digimonId: nextId,
         path: [...current.path, { digimonId: nextId, learnedMoves: [] }],
@@ -153,6 +165,7 @@ function findShortestPath(
     }
 
     for (const prevId of currentDigimon.neighBours.prev) {
+      if (excludedDigimonIds.includes(prevId)) continue;
       queue.push({
         digimonId: prevId,
         path: [...current.path, { digimonId: prevId, learnedMoves: [] }],

--- a/src/lib/path-finder/worker.ts
+++ b/src/lib/path-finder/worker.ts
@@ -4,7 +4,8 @@ self.onmessage = function (e) {
   const result = findPath(
     e.data.originDigimon,
     e.data.targetDigimon,
-    e.data.skills
+    e.data.skills,
+    e.data.excludedDigimonIds
   );
   self.postMessage(result);
 };


### PR DESCRIPTION
## Summary
- add `ExcludedDigimonSelector` component so users can exclude digimon from results
- allow passing excluded digimon IDs into path finder worker and algorithm
- update `App.tsx` to support excluding digimon

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68431c327acc83249e2a0fb8779ed573